### PR TITLE
Correct explainer around invalid setAttribute

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -552,7 +552,8 @@ html`<button @click=${handleClick}></button>`
 > [!NOTE]
 > These sigils do not require HTML parser changes, since they are valid,
 > parsable attribute names. They are also extremely unlikely to conflict with
-> any real-world attribute names.
+> any real-world attribute names, partly because until recently they were invalid to use with DOM APIs
+> like `setAttribute()`.
 
 [^1]: HTML does have some facility for event handler attributes,
 but these are generally discouraged and don't have access to the lexical scope

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -552,8 +552,7 @@ html`<button @click=${handleClick}></button>`
 > [!NOTE]
 > These sigils do not require HTML parser changes, since they are valid,
 > parsable attribute names. They are also extremely unlikely to conflict with
-> any real-world attribute names because they are _invalid_ to use with DOM APIs
-> like `setAttribute()`.
+> any real-world attribute names.
 
 [^1]: HTML does have some facility for event handler attributes,
 but these are generally discouraged and don't have access to the lexical scope


### PR DESCRIPTION
These are valid now since https://github.com/whatwg/dom/pull/1079, which is supported in Firefox and Chrome (https://caniuse.com/mdn-api_element_setattribute_html_name_validity).